### PR TITLE
Adding CMake FindDARTS and logic to get the DARTS library.

### DIFF
--- a/04_DECARD_HPC/DECARD/CMakeLists.txt
+++ b/04_DECARD_HPC/DECARD/CMakeLists.txt
@@ -52,6 +52,20 @@ if (PROFILE_MODE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DPROFILE_MODE=${PROFILE_MODE}")
 endif (PROFILE_MODE)
 
+if (DARTS)
+  set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules")
+  cmake_policy(PUSH)
+  cmake_policy(SET CMP0074 NEW) # Allow to use DARTS_ROOT without having to explicitely defined it (envarimental variable)
+    find_package(DARTS)
+  cmake_policy(POP)
+
+  if (DARTS_FOUND)
+    message_yellow("Building with the cool DARTS")
+  else ()
+    message_red("Couldn't find DARTS")
+  endif (DARTS_FOUND)
+endif(DARTS)
+
 # ## Check for ACCELERATOR
 # if (EPIPH)
 #   # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -le-hal -le-loader -lpthread")

--- a/04_DECARD_HPC/DECARD/README.md
+++ b/04_DECARD_HPC/DECARD/README.md
@@ -1,0 +1,10 @@
+# how to run with darts
+
+In order to run with DARTS make sure you have DARTS built and install in a given location
+To build DARTS do:
+
+```
+cmake .. -DHWLOC_ROOT={location_to_hwloc} -DTBB_ROOT={location_to_intel_tbb} -DCMAKE_INSTALL_PREFIX={installation_location} 
+```
+
+

--- a/04_DECARD_HPC/DECARD/cmake/Modules/FindDARTS.cmake
+++ b/04_DECARD_HPC/DECARD/cmake/Modules/FindDARTS.cmake
@@ -1,0 +1,114 @@
+################################################################################
+#                                                                              #
+# Copyright (c) 2011-2014, University of Delaware                              # 
+# All rights reserved.                                                         #
+#                                                                              #
+# Redistribution and use in source and binary forms, with or without           # 
+# modification, are permitted provided that the following conditions           # 
+# are met:                                                                     #
+#                                                                              #
+# 1. Redistributions of source code must retain the above copyright            # 
+# notice, this list of conditions and the following disclaimer.                # 
+#                                                                              #
+# 2. Redistributions in binary form must reproduce the above copyright         # 
+# notice, this list of conditions and the following disclaimer in the          # 
+# documentation and/or other materials provided with the distribution.         # 
+#                                                                              #
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS          # 
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT            # 
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS            # 
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE               # 
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,         # 
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,         # 
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;             # 
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER             # 
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT           # 
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN            # 
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE              # 
+# POSSIBILITY OF SUCH DAMAGE.                                                  # 
+#                                                                              #
+################################################################################
+
+#[=======================================================================[.rst:
+FindDARTS
+-------
+
+Finds the DARTS library. The Delaware Adaptive Runtime System
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported targets, if found:
+
+``darts::darts``
+  The DARTS library
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables:
+
+``DARTS_FOUND``
+  True if the system has the Foo library.
+``DARTS_VERSION``
+  The version of the Foo library which was found.
+``DARTS_INCLUDE_DIRS``
+  Include directories needed to use Foo.
+``DARTS_LIBRARIES``
+  Libraries needed to link to Foo.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``DARTS_INCLUDE_DIR``
+  The directory containing ``foo.h``.
+``DARTS_LIBRARY``
+  The path to the Foo library.
+
+#]=======================================================================]
+
+
+set(POSSIBLE_LIB_LOCATION /usr/local/darts)
+
+find_path(DARTS_INCLUDE_DIR "darts.h" 
+  ${POSSIBLE_LIB_LOCATION}/include
+)
+
+find_library(DARTS_LIB NAMES darts
+  PATHS ${POSSIBLE_LIB_LOCATION}/lib
+)
+find_library(CODELET_LIB NAMES codelet
+  PATHS ${POSSIBLE_LIB_LOCATION}/lib
+)
+find_library(AMM_LIB NAMES amm 
+  PATHS ${POSSIBLE_LIB_LOCATION}/lib
+)
+find_library(COMMON_LIB NAMES common
+  PATHS ${POSSIBLE_LIB_LOCATION}/lib
+)
+find_library(SCHEDUELR_LIB NAMES scheduler  
+  PATHS ${POSSIBLE_LIB_LOCATION}/lib
+)
+find_library(SCHEDUELR_LIB NAMES threadlocal 
+  PATHS ${POSSIBLE_LIB_LOCATION}/lib
+)
+
+if (DARTS_LIB AND CODELET_LIB AND AMM_LIB AND COMMON_LIB AND SCHEDUELR_LIB AND SCHEDUELR_LIB)
+  set(DARTS_LIBRARIES ${DARTS_LIB} ${CODELET_LIB} ${AMM_LIB} ${COMMON_LIB} ${SCHEDUELR_LIB} ${SCHEDUELR_LIB})
+endif(DARTS_LIB AND CODELET_LIB AND AMM_LIB AND COMMON_LIB AND SCHEDUELR_LIB AND SCHEDUELR_LIB)
+
+set(VERSION_DARTS 0.1)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(DARTS DEFAULT_MSG
+  DARTS_LIBRARIES
+  DARTS_INCLUDE_DIR
+  VERSION_DARTS 0.1)
+
+if(DARTS_FOUND)
+  set( DARTS_INCLUDE_DIR ${DARTS_INCLUDE_DIR} )
+  set( DARTS_LIBRARIES ${DARTS_LIBRARIES} )
+endif(DARTS_FOUND)
+


### PR DESCRIPTION
Additionally adding some documentation.

I've added some placeholder `README.md` for documenting how to run with darts. 

Additionally I have implemented `FindDARTS.cmake` Module which will search for the darts libraries and define the `DARTS_LIBRARIES` and `DARTS_INCLUDES` variables. 

Thse are tested in the CMakeFile, but they are not yet used